### PR TITLE
v1.3

### DIFF
--- a/droplogger.py
+++ b/droplogger.py
@@ -226,6 +226,7 @@ def main():
         cfg.set('Files', 'kwfile', '')
         cfg.set('Booleans', 'isVerbose', 'False')
         cfg.set('Bosses', 'bosses', 'Lotus, Damien, Lucid, Will, Divine King Slime, Dusk, Djunkel, Heretic Hilla, Black Mage, Seren, Kalos, Kaling')
+        bosslist = ['Lotus', 'Damien', 'Lucid', 'Will', 'Divine King Slime', 'Dusk', 'Djunkel', 'Heretic Hilla', 'Black Mage', 'Seren', 'Kalos', 'Kaling']
         with open('dlconfig.ini', 'w') as cfgfile:
             cfg.write(cfgfile)
     

--- a/droplogger.py
+++ b/droplogger.py
@@ -217,7 +217,7 @@ def main():
         xltfile.set(files['xltfile'])
         kwfile.set(files['kwfile'])
         isVerbose.set(booleans.getboolean('isVerbose'))
-        bosslist = bosses['bosses'].split(',')
+        bosslist = bosses['bosses'].split(', ')
     except (FileNotFoundError, KeyError) as e:
         cfg.add_section('Files')
         cfg.add_section('Booleans')


### PR DESCRIPTION
**Changes:**
- DLT now only looks for _tesseract.exe_ within a subfolder named _tess_ in its current directory.
  - This allows for a static version of Tesseract to be bundled with DLT and distributed as a single binary.
- The list of bosses is no longer hard-coded and is now instead retrieved from the config file (_dlconfig.ini_).
  - If the config file does not exist, DLT will generate a new one, then initialise a default list of bosses (same as the original hard-coded list).
  - Config files generated before v1.3 must be updated to include a Bosses section with a key named _bosses_ and multiple values, e.g. _bosses = boss1, boss2, boss3, etc._
  - DLT will throw an exception if it cannot find this new section.